### PR TITLE
Permission to break spawners

### DIFF
--- a/Plugin/src/main/java/dev/rosewood/rosestacker/listener/BlockListener.java
+++ b/Plugin/src/main/java/dev/rosewood/rosestacker/listener/BlockListener.java
@@ -103,6 +103,12 @@ public class BlockListener implements Listener {
         Location dropLocation = block.getLocation().clone().add(0.5, 0.5, 0.5);
 
         if (isSpawner) {
+
+            if (!event.getPlayer().hasPermission("rosestacker.spawnermine")){
+                event.setCancelled(true);
+                return;
+            }
+
             if (!stackManager.isSpawnerStackingEnabled())
                 return;
 

--- a/Plugin/src/main/resources/plugin.yml
+++ b/Plugin/src/main/resources/plugin.yml
@@ -38,6 +38,7 @@ permissions:
       rosestacker.stacktool.give: true
       rosestacker.silktouch: true
       rosestacker.spawnerconvert: true
+      rosestacker.spawnermine: true
   rosestacker.reload:
     description: Allows using the reload command
     default: op
@@ -73,4 +74,7 @@ permissions:
     default: op
   rosestacker.spawnerconvert:
     description: Allows converting spawners with mob spawn eggs
+    default: op
+  rosestacker.spawnermine:
+    description: Allows for breaking spawners
     default: op


### PR DESCRIPTION
due to this request:
"""
SilverCoreToday at 6:11 PM
How about this: (the feature safe-spawners gave me that idea) can we get an integration with permissions, aka same thing as not having silk touch, spawner doesn’t get mined or lost, instead the player will get a message that they don’t have sufficient permission? If that can already be done, please teach me. Otherwise, this would be very helpful
"""
rosestacker.break