### PR TITLE
Enable or disable stacking based on TPS hysteresis

### DIFF
--- a/Plugin/src/main/java/dev/rosewood/rosestacker/manager/ConfigurationManager.java
+++ b/Plugin/src/main/java/dev/rosewood/rosestacker/manager/ConfigurationManager.java
@@ -220,6 +220,10 @@ public class ConfigurationManager extends AbstractConfigurationManager {
         MISC_MYTHICMOBS_ALLOW_STACKING("misc-settings.mythicmobs-allow-stacking", false, "Should mobs owned by MythicMobs be allowed to stack?", "This is recommended to keep set to false unless you specifically only change mob attributes"),
         MISC_SPAWNER_PERSISTENT_COMPATIBILITY("misc-settings.spawner-persistent-compatibility", true, "Some plugins like Jobs, mcMMO, and RoseLoot store special data for spawner mobs.", "Disabling this will cause the functionality within those plugins to break."),
         MISC_STACK_STATISTICS("misc-settings.stack-statistics", true, "Should statistics be accurately tracked for stacked entities?", "This can cause issues if you expect players to kill multiple billion mobs"),
+        PERFORMANCE_SETTINGS("performance-settings", null, "Plugin behavior based on server performance, and other performance tweaks"),
+        PERFORMANCE_TPS_TOGGLE("performance-settings.tps-toggle.enabled", false, "Should stacking be automatically disabled or enabled based on server TPS?", "Stacks created during periods of low TPS will remain stacked"),
+        PERFORMANCE_TPS_ENABLE_BELOW("performance-settings.tps-toggle.enable-below", 16D, "When should we enable the stacking?", "Should be lower than re-enable-above. Stacking will remain enabled until disable-above is reached"),
+        PERFORMANCE_TPS_DISABLE_ABOVE("performance-settings.tps-toggle.disable-above", 18D, "When should we disable the stacking?"),
         ;
 
         private final String key;


### PR DESCRIPTION
I tested using [Stress](https://www.spigotmc.org/resources/stress.79374/), using ``/stress test=entity amount=5000 duration=120 range=10``

This is a pretty basic PR, I didn't want to add too many options so I wouldn't over-complicate it. Right now the TPS check runs every 30 seconds using ``runTaskAsynchronously`` from the ``StackManager`` class. Maybe it would be nice to add the option so the end user can also check the frequency. For now I guess it gets the job done.

The feature is **disabled by default**, kicking in at 16TPS, and disabling measures after 18TPS is reached.

I added the disabled status using ``isEntityStackingTemporarilyDisabled``, so I didn't have to modify every single class.