### PR TITLE
Add simple ItemPickupEvent

### DIFF
--- a/Plugin/src/main/java/dev/rosewood/rosestacker/event/ItemPickupEvent.java
+++ b/Plugin/src/main/java/dev/rosewood/rosestacker/event/ItemPickupEvent.java
@@ -1,0 +1,66 @@
+package dev.rosewood.rosestacker.event;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityEvent;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+public class ItemPickupEvent extends EntityEvent implements Cancellable {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final ItemStack item;
+    private boolean cancelled;
+
+    /**
+     * @param entity The entity picking up item
+     * @param item   The item being picking up from stacked dropped items
+     */
+    public ItemPickupEvent(@NotNull final LivingEntity entity, @NotNull final ItemStack item) {
+        super(entity);
+        this.item = item;
+    }
+
+    /**
+     * Gets the entity picking up items.
+     *
+     * @return the entity
+     */
+    @NotNull
+    @Override
+    public LivingEntity getEntity() {
+        return (LivingEntity) entity;
+    }
+
+    /**
+     * Gets the items being picking up.
+     *
+     * @return the itemStack being picking up
+     */
+    @NotNull
+    public ItemStack getItem() {
+        return this.item;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+}

--- a/Plugin/src/main/java/dev/rosewood/rosestacker/listener/ItemListener.java
+++ b/Plugin/src/main/java/dev/rosewood/rosestacker/listener/ItemListener.java
@@ -1,6 +1,7 @@
 package dev.rosewood.rosestacker.listener;
 
 import dev.rosewood.rosegarden.RosePlugin;
+import dev.rosewood.rosestacker.event.ItemPickupEvent;
 import dev.rosewood.rosestacker.manager.ConfigurationManager;
 import dev.rosewood.rosestacker.manager.StackManager;
 import dev.rosewood.rosestacker.manager.StackSettingManager;
@@ -10,11 +11,14 @@ import dev.rosewood.rosestacker.utils.PersistentDataUtils;
 import dev.rosewood.rosestacker.utils.StackerUtils;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Container;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
 import org.bukkit.event.EventHandler;
@@ -164,6 +168,12 @@ public class ItemListener implements Listener {
 
         boolean willPickupAll = inventorySpace >= stackedItem.getStackSize();
         int amount = willPickupAll ? stackedItem.getStackSize() - target.getAmount() : inventorySpace;
+
+        // Fire the event to allow other plugins to manipulate the items before we pick up partial items from stacked item
+        ItemPickupEvent event = new ItemPickupEvent((LivingEntity) eventEntity, target);
+        Bukkit.getPluginManager().callEvent(event);
+        if (event.isCancelled())
+            return false;
 
         this.addItemStackAmountToInventory(inventory, target, amount);
 


### PR DESCRIPTION
This event will throw when player try to pick up partial items from stacked dropped items on the ground, since the RoseStacker cancels the EntityPickupItemEvent if player doesn't pick up the entire stacked item from ground.