### PR TITLE
Adds new `max-egg-stack-size` option for chicken stacks

### DIFF
--- a/Plugin/src/main/java/dev/rosewood/rosestacker/listener/EntityListener.java
+++ b/Plugin/src/main/java/dev/rosewood/rosestacker/listener/EntityListener.java
@@ -490,9 +490,16 @@ public class EntityListener implements Listener {
         if (!stackedEntity.getStackSettings().getSettingValue(EntityStackSettings.CHICKEN_MULTIPLY_EGG_DROPS_BY_STACK_SIZE).getBoolean())
             return;
 
-        event.getItemDrop().remove();
-        List<ItemStack> items = GuiUtil.getMaterialAmountAsItemStacks(Material.EGG, stackedEntity.getStackSize());
-        this.stackManager.preStackItems(items, event.getEntity().getLocation());
+        if (stackedEntity.getStackSize() > stackedEntity.getStackSettings().getSettingValue(EntityStackSettings.MAX_EGG_STACK_SIZE).getInt()) {
+            event.getItemDrop().remove();
+            List<ItemStack> items = GuiUtil.getMaterialAmountAsItemStacks(Material.EGG, stackedEntity.getStackSettings().getSettingValue(EntityStackSettings.MAX_EGG_STACK_SIZE).getInt());
+            this.stackManager.preStackItems(items, event.getEntity().getLocation());
+        }
+        else {
+            event.getItemDrop().remove();
+            List<ItemStack> items = GuiUtil.getMaterialAmountAsItemStacks(Material.EGG, stackedEntity.getStackSize());
+            this.stackManager.preStackItems(items, event.getEntity().getLocation());
+        }
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/Plugin/src/main/java/dev/rosewood/rosestacker/stack/settings/EntityStackSettings.java
+++ b/Plugin/src/main/java/dev/rosewood/rosestacker/stack/settings/EntityStackSettings.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.bukkit.Material;
 import org.bukkit.entity.Ageable;
@@ -47,6 +46,7 @@ public class EntityStackSettings extends StackSettings {
 
     // Entity-specific settings
     public static final String CHICKEN_MULTIPLY_EGG_DROPS_BY_STACK_SIZE = "multiply-egg-drops-by-stack-size";
+    public static final String MAX_EGG_STACK_SIZE = "max-egg-stack-size";
     public static final String CREEPER_EXPLODE_KILL_ENTIRE_STACK = "explode-kill-entire-stack";
     public static final String SHEEP_SHEAR_ALL_SHEEP_IN_STACK = "shear-all-sheep-in-stack";
     public static final String SHEEP_PERCENTAGE_OF_WOOL_TO_REGROW_PER_GRASS_EATEN = "percentage-of-wool-to-regrow-per-grass-eaten";
@@ -94,7 +94,10 @@ public class EntityStackSettings extends StackSettings {
         this.extraSettings = new HashMap<>();
 
         switch (this.entityType) {
-            case CHICKEN -> this.putSetting(CHICKEN_MULTIPLY_EGG_DROPS_BY_STACK_SIZE, true);
+            case CHICKEN -> {
+                this.putSetting(CHICKEN_MULTIPLY_EGG_DROPS_BY_STACK_SIZE, true);
+                this.putSetting(MAX_EGG_STACK_SIZE, 10000);
+            }
             case CREEPER -> this.putSetting(CREEPER_EXPLODE_KILL_ENTIRE_STACK, false);
             case SHEEP -> {
                 this.putSetting(SHEEP_SHEAR_ALL_SHEEP_IN_STACK, true);


### PR DESCRIPTION
As stated in the title, this PR adds in a `max-egg-stack-size` option for chicken entity stacks.

This does not fix an open GitHub issue, and instead fixes an issue where chicken entity stacks would drop eggs equaling their current stack size, i.e. a chicken stack with three billion chickens would drop 3 billion eggs. 

I set the default value for this option to 10,000, let me know if that's too low or too high.