### PR TITLE
Use event loot

### DIFF
--- a/NMS/Wrapper/src/main/java/dev/rosewood/rosestacker/nms/storage/AbstractSimpleStackedEntityDataStorage.java
+++ b/NMS/Wrapper/src/main/java/dev/rosewood/rosestacker/nms/storage/AbstractSimpleStackedEntityDataStorage.java
@@ -54,6 +54,13 @@ public abstract class AbstractSimpleStackedEntityDataStorage extends StackedEnti
     }
 
     @Override
+    public List<EntityDataEntry> peek(int amount) {
+        EntityDataEntry[] entries = new EntityDataEntry[amount];
+        Arrays.fill(entries, this.copy());
+        return Arrays.asList(entries);
+    }
+
+    @Override
     public EntityDataEntry pop() {
         if (this.isEmpty())
             throw new IllegalStateException("No more data is available");

--- a/NMS/Wrapper/src/main/java/dev/rosewood/rosestacker/nms/storage/StackedEntityDataStorage.java
+++ b/NMS/Wrapper/src/main/java/dev/rosewood/rosestacker/nms/storage/StackedEntityDataStorage.java
@@ -72,6 +72,14 @@ public abstract class StackedEntityDataStorage {
     public abstract EntityDataEntry peek();
 
     /**
+     * Gets the given amount of entities from the list
+     *
+     * @param amount The amount of entities to peek
+     * @return A List of StackedEntityDataEntry objects for the entities at the front of the list
+     */
+    public abstract List<EntityDataEntry> peek(int amount);
+
+    /**
      * Gets and removes an entity from the list
      *
      * @return A StackedEntityDataEntry object for the entity at the front of the list

--- a/NMS/v1_16_R3/src/main/java/dev/rosewood/rosestacker/nms/v1_16_R3/storage/NBTStackedEntityDataStorage.java
+++ b/NMS/v1_16_R3/src/main/java/dev/rosewood/rosestacker/nms/v1_16_R3/storage/NBTStackedEntityDataStorage.java
@@ -91,6 +91,15 @@ public class NBTStackedEntityDataStorage extends StackedEntityDataStorage {
     }
 
     @Override
+    public List<EntityDataEntry> peek(int amount) {
+        NBTTagCompound[] array = this.data.toArray(new NBTTagCompound[0]);
+        List<EntityDataEntry> peeked = new ArrayList<>(amount);
+        for (int i = 0; i < amount; i++)
+            peeked.add(new NBTEntityDataEntry(this.rebuild(array[i])));
+        return peeked;
+    }
+
+    @Override
     public NBTEntityDataEntry pop() {
         return new NBTEntityDataEntry(this.rebuild(this.data.remove()));
     }

--- a/NMS/v1_17_R1/src/main/java/dev/rosewood/rosestacker/nms/v1_17_R1/storage/NBTStackedEntityDataStorage.java
+++ b/NMS/v1_17_R1/src/main/java/dev/rosewood/rosestacker/nms/v1_17_R1/storage/NBTStackedEntityDataStorage.java
@@ -89,6 +89,15 @@ public class NBTStackedEntityDataStorage extends StackedEntityDataStorage {
     }
 
     @Override
+    public List<EntityDataEntry> peek(int amount) {
+        CompoundTag[] array = this.data.toArray(new CompoundTag[0]);
+        List<EntityDataEntry> peeked = new ArrayList<>(amount);
+        for (int i = 0; i < amount; i++)
+            peeked.add(new NBTEntityDataEntry(this.rebuild(array[i])));
+        return peeked;
+    }
+
+    @Override
     public NBTEntityDataEntry pop() {
         return new NBTEntityDataEntry(this.rebuild(this.data.remove()));
     }

--- a/NMS/v1_18_R2/src/main/java/dev/rosewood/rosestacker/nms/v1_18_R2/storage/NBTStackedEntityDataStorage.java
+++ b/NMS/v1_18_R2/src/main/java/dev/rosewood/rosestacker/nms/v1_18_R2/storage/NBTStackedEntityDataStorage.java
@@ -89,6 +89,15 @@ public class NBTStackedEntityDataStorage extends StackedEntityDataStorage {
     }
 
     @Override
+    public List<EntityDataEntry> peek(int amount) {
+        CompoundTag[] array = this.data.toArray(new CompoundTag[0]);
+        List<EntityDataEntry> peeked = new ArrayList<>(amount);
+        for (int i = 0; i < amount; i++)
+            peeked.add(new NBTEntityDataEntry(this.rebuild(array[i])));
+        return peeked;
+    }
+
+    @Override
     public NBTEntityDataEntry pop() {
         return new NBTEntityDataEntry(this.rebuild(this.data.remove()));
     }

--- a/NMS/v1_19_R3/src/main/java/dev/rosewood/rosestacker/nms/v1_19_R3/storage/NBTStackedEntityDataStorage.java
+++ b/NMS/v1_19_R3/src/main/java/dev/rosewood/rosestacker/nms/v1_19_R3/storage/NBTStackedEntityDataStorage.java
@@ -89,6 +89,15 @@ public class NBTStackedEntityDataStorage extends StackedEntityDataStorage {
     }
 
     @Override
+    public List<EntityDataEntry> peek(int amount) {
+        CompoundTag[] array = this.data.toArray(new CompoundTag[0]);
+        List<EntityDataEntry> peeked = new ArrayList<>(amount);
+        for (int i = 0; i < amount; i++)
+            peeked.add(new NBTEntityDataEntry(this.rebuild(array[i])));
+        return peeked;
+    }
+
+    @Override
     public NBTEntityDataEntry pop() {
         return new NBTEntityDataEntry(this.rebuild(this.data.remove()));
     }

--- a/NMS/v1_20_R3/src/main/java/dev/rosewood/rosestacker/nms/v1_20_R3/storage/NBTStackedEntityDataStorage.java
+++ b/NMS/v1_20_R3/src/main/java/dev/rosewood/rosestacker/nms/v1_20_R3/storage/NBTStackedEntityDataStorage.java
@@ -89,6 +89,15 @@ public class NBTStackedEntityDataStorage extends StackedEntityDataStorage {
     }
 
     @Override
+    public List<EntityDataEntry> peek(int amount) {
+        CompoundTag[] array = this.data.toArray(new CompoundTag[0]);
+        List<EntityDataEntry> peeked = new ArrayList<>(amount);
+        for (int i = 0; i < amount; i++)
+            peeked.add(new NBTEntityDataEntry(this.rebuild(array[i])));
+        return peeked;
+    }
+
+    @Override
     public NBTEntityDataEntry pop() {
         return new NBTEntityDataEntry(this.rebuild(this.data.remove()));
     }

--- a/NMS/v1_20_R4/src/main/java/dev/rosewood/rosestacker/nms/v1_20_R4/storage/NBTStackedEntityDataStorage.java
+++ b/NMS/v1_20_R4/src/main/java/dev/rosewood/rosestacker/nms/v1_20_R4/storage/NBTStackedEntityDataStorage.java
@@ -89,6 +89,15 @@ public class NBTStackedEntityDataStorage extends StackedEntityDataStorage {
     }
 
     @Override
+    public List<EntityDataEntry> peek(int amount) {
+        CompoundTag[] array = this.data.toArray(new CompoundTag[0]);
+        List<EntityDataEntry> peeked = new ArrayList<>(amount);
+        for (int i = 0; i < amount; i++)
+            peeked.add(new NBTEntityDataEntry(this.rebuild(array[i])));
+        return peeked;
+    }
+
+    @Override
     public NBTEntityDataEntry pop() {
         return new NBTEntityDataEntry(this.rebuild(this.data.remove()));
     }

--- a/NMS/v1_21_R1/src/main/java/dev/rosewood/rosestacker/nms/v1_21_R1/storage/NBTStackedEntityDataStorage.java
+++ b/NMS/v1_21_R1/src/main/java/dev/rosewood/rosestacker/nms/v1_21_R1/storage/NBTStackedEntityDataStorage.java
@@ -89,6 +89,15 @@ public class NBTStackedEntityDataStorage extends StackedEntityDataStorage {
     }
 
     @Override
+    public List<EntityDataEntry> peek(int amount) {
+        CompoundTag[] array = this.data.toArray(new CompoundTag[0]);
+        List<EntityDataEntry> peeked = new ArrayList<>(amount);
+        for (int i = 0; i < amount; i++)
+            peeked.add(new NBTEntityDataEntry(this.rebuild(array[i])));
+        return peeked;
+    }
+
+    @Override
     public NBTEntityDataEntry pop() {
         return new NBTEntityDataEntry(this.rebuild(this.data.remove()));
     }

--- a/NMS/v1_21_R2/src/main/java/dev/rosewood/rosestacker/nms/v1_21_R2/storage/NBTStackedEntityDataStorage.java
+++ b/NMS/v1_21_R2/src/main/java/dev/rosewood/rosestacker/nms/v1_21_R2/storage/NBTStackedEntityDataStorage.java
@@ -101,6 +101,15 @@ public class NBTStackedEntityDataStorage extends StackedEntityDataStorage {
     }
 
     @Override
+    public List<EntityDataEntry> peek(int amount) {
+        CompoundTag[] array = this.data.toArray(new CompoundTag[0]);
+        List<EntityDataEntry> peeked = new ArrayList<>(amount);
+        for (int i = 0; i < amount; i++)
+            peeked.add(new NBTEntityDataEntry(this.rebuild(array[i])));
+        return peeked;
+    }
+
+    @Override
     public NBTEntityDataEntry pop() {
         return new NBTEntityDataEntry(this.rebuild(this.data.remove()));
     }

--- a/NMS/v1_21_R3/src/main/java/dev/rosewood/rosestacker/nms/v1_21_R3/storage/NBTStackedEntityDataStorage.java
+++ b/NMS/v1_21_R3/src/main/java/dev/rosewood/rosestacker/nms/v1_21_R3/storage/NBTStackedEntityDataStorage.java
@@ -101,6 +101,15 @@ public class NBTStackedEntityDataStorage extends StackedEntityDataStorage {
     }
 
     @Override
+    public List<EntityDataEntry> peek(int amount) {
+        CompoundTag[] array = this.data.toArray(new CompoundTag[0]);
+        List<EntityDataEntry> peeked = new ArrayList<>(amount);
+        for (int i = 0; i < amount; i++)
+            peeked.add(new NBTEntityDataEntry(this.rebuild(array[i])));
+        return peeked;
+    }
+
+    @Override
     public NBTEntityDataEntry pop() {
         return new NBTEntityDataEntry(this.rebuild(this.data.remove()));
     }

--- a/NMS/v1_21_R4/src/main/java/dev/rosewood/rosestacker/nms/v1_21_R4/storage/NBTStackedEntityDataStorage.java
+++ b/NMS/v1_21_R4/src/main/java/dev/rosewood/rosestacker/nms/v1_21_R4/storage/NBTStackedEntityDataStorage.java
@@ -102,6 +102,15 @@ public class NBTStackedEntityDataStorage extends StackedEntityDataStorage {
     }
 
     @Override
+    public List<EntityDataEntry> peek(int amount) {
+        CompoundTag[] array = this.data.toArray(new CompoundTag[0]);
+        List<EntityDataEntry> peeked = new ArrayList<>(amount);
+        for (int i = 0; i < amount; i++)
+            peeked.add(new NBTEntityDataEntry(this.rebuild(array[i])));
+        return peeked;
+    }
+
+    @Override
     public NBTEntityDataEntry pop() {
         return new NBTEntityDataEntry(this.rebuild(this.data.remove()));
     }

--- a/Plugin/src/main/java/dev/rosewood/rosestacker/stack/StackedEntity.java
+++ b/Plugin/src/main/java/dev/rosewood/rosestacker/stack/StackedEntity.java
@@ -721,10 +721,15 @@ public class StackedEntity extends Stack<EntityStackSettings> implements Compara
             if (event == null) {
                 this.dropStackLoot(new ArrayList<>(), experience);
             } else {
-                EntityDrops drops = calculateDrops(this.getStackSize(), experience, event.getDrops());
-                event.getDrops().clear();
-                event.getDrops().addAll(drops.getDrops());
-                event.setDroppedExp(drops.getExperience());
+                if (SettingKey.ENTITY_KILL_DELAY_NEXT_SPAWN.get()) {
+                    this.dropStackLoot(new ArrayList<>(event.getDrops()), experience);
+                    event.getDrops().clear();
+                } else {
+                    EntityDrops drops = calculateDrops(this.getStackSize(), experience, event.getDrops());
+                    event.getDrops().clear();
+                    event.getDrops().addAll(drops.getDrops());
+                    event.setDroppedExp(drops.getExperience());
+                }
             }
 
             if (this.entity.getType() == EntityType.MAGMA_CUBE)
@@ -769,9 +774,15 @@ public class StackedEntity extends Stack<EntityStackSettings> implements Compara
             if (event == null) {
                 this.dropPartialStackLoot(killedEntities, new ArrayList<>(), EntityUtils.getApproximateExperience(this.entity));
             } else {
-                EntityDrops drops = calculateDrops(killedEntities.size(), event.getDroppedExp(), event.getDrops());
-                event.getDrops().addAll(drops.getDrops());
-                event.setDroppedExp(drops.getExperience());
+                if (SettingKey.ENTITY_KILL_DELAY_NEXT_SPAWN.get()) {
+                    this.dropPartialStackLoot(killedEntities, new ArrayList<>(event.getDrops()), event.getDroppedExp());
+                    event.getDrops().clear();
+                    event.setDroppedExp(0);
+                } else {
+                    EntityDrops drops = calculateDrops(killedEntities.size(), event.getDroppedExp(), event.getDrops());
+                    event.getDrops().addAll(drops.getDrops());
+                    event.setDroppedExp(drops.getExperience());
+                }
             }
         } else if (SettingKey.ENTITY_DROP_ACCURATE_EXP.get()) {
             if (event == null) {


### PR DESCRIPTION
This Pull Request makes the `StackedEntity#killEntireStack(EntityDeathEvent)` and `StackedEntity#killPartialStack(EntityDeathEvent, int)` methods change the `EntityDeathEvent#getDrops()` and `EntityDeathEvent#getExp()`, instead of handling drops and experience separately, when applicable.

This is a nice addition, as it allows other plugins to get the drops and experience after RoseStacker handles its logic.

There is a better way to allow other plugins to capture the drops and experience left by a stacked entity by firing an event with the drops and experience, but right now this Pull Request is all I need to get something done for a client of mine.

Feel free to change anything.