### PR TITLE
Don't let unstacked entities inherit the previous entity's killer

### DIFF
--- a/NMS/Wrapper/src/main/java/dev/rosewood/rosestacker/nms/NMSHandler.java
+++ b/NMS/Wrapper/src/main/java/dev/rosewood/rosestacker/nms/NMSHandler.java
@@ -38,7 +38,14 @@ public interface NMSHandler {
             "uuid", "pos", "rotation", "world_uuid_most", "world_uuid_least",
             "motion", "on_ground", "fall_distance", "leash", "patrolling",
             "patrol_target", "raid_id", "wave", "angry_at", "anger_time", "pose",
-            "last_pose_tick"
+            "last_pose_tick",
+
+            // Combat attribution belongs to the entity that was actually hit, never to the next one in the stack.
+            // 1.21.5+ persists these, so without stripping them a freshly unstacked entity spawns already marked as
+            // "killed by" whoever killed the entity before it, which credits its later environmental death (fire,
+            // lava, drowning, ...) to that player. Killer propagation is applied deliberately where it is wanted,
+            // see StackedEntity#calculateEntityDrops.
+            "last_hurt_by_player", "last_hurt_by_player_memory_time"
     );
 
     List<String> UNSAFE_NBT_KEYS = List.of(


### PR DESCRIPTION
### The problem

Stand a stack of mobs in fire, kill a single one of them with a sword, then walk away. The rest of the stack burns down on its own, and every one of those deaths still pays out experience, player-only loot and kill credit to the player who landed that one hit.

### Why it happens

1.21.5 started persisting combat attribution in entity NBT:

```java
// LivingEntity#addAdditionalSaveData
if (this.lastHurtByPlayer != null) {
    this.lastHurtByPlayer.store(output, "last_hurt_by_player");
    output.putInt("last_hurt_by_player_memory_time", this.lastHurtByPlayerMemoryTime);
}
```

`StackedEntity#decreaseStackSize` builds the next entity in the stack from a saved tag (`EntityDataEntry#createEntity` -> `entity.load(...)`), and neither `REMOVABLE_NBT_KEYS` nor `UNSAFE_NBT_KEYS` strips those two keys. So the replacement spawns already flagged as killed by whoever killed the entity before it.

That flag is exactly what the server uses to decide a death was player caused:

- `getExpReward` gates experience on `lastHurtByPlayerMemoryTime > 0`
- `dropAllDeathLoot` passes it as the `playerKilled` flag for `killed_by_player` loot conditions
- `CraftLivingEntity#getKiller` reads `lastHurtByPlayer`, which is what plugins listening for `EntityDeathEvent` use for attribution

With `data-storage-type: SIMPLE` it also compounds, because `AbstractSimpleStackedEntityDataStorage#copy` snapshots the live main entity on every `pop()` -- so the flag gets copied forward again for each entity in the stack rather than dying out with the original.

### Reproduction

`data-storage-type: SIMPLE`, `kill-transfer-fire: true`, on 1.21.5 or newer. Stack a few hundred sheep, stand the stack in a fire block, kill one with a sword and stop attacking. The rest of the stack burns down on its own and keeps dropping experience, and any plugin counting kills off `EntityDeathEvent#getEntity().getKiller()` keeps counting them for that player.

### The fix

Strip `last_hurt_by_player` and `last_hurt_by_player_memory_time` from cloned entity NBT. Combat attribution is per entity and shouldn't be inherited by the entity that replaces it.

This doesn't affect intentional stack kills. Killer propagation for multi kill and kill-entire-stack loot is applied explicitly in `StackedEntity#calculateEntityDrops` via `NMSHandler#setLastHurtBy`, and an entity the player actually hits gets the flag from the damage itself, so killing a stack one entity at a time with a sword still credits every kill and still applies looting.